### PR TITLE
Migrate from BinaryData to ByteVector

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     exclude group: 'ch.qos.logback'
   }
   // eclair core
-  implementation 'fr.acinq.eclair:eclair-core_2.11:0.2-android-beta17'
+  implementation 'fr.acinq.eclair:eclair-core_2.11:0.2-android-SNAPSHOT'
   // database orm
   implementation 'org.greenrobot:greendao:3.2.2'
   // required for greendao encryption, disabled for now

--- a/app/src/androidTest/java/fr/acinq/eclair/blockchain/electrum/ElectrumClientTest.java
+++ b/app/src/androidTest/java/fr/acinq/eclair/blockchain/electrum/ElectrumClientTest.java
@@ -29,10 +29,9 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.testkit.JavaTestKit;
-import fr.acinq.bitcoin.BinaryData;
+import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.bitcoin.Crypto;
 import fr.acinq.bitcoin.Transaction;
-import fr.acinq.bitcoin.package$;
 
 public class ElectrumClientTest {
 
@@ -53,6 +52,7 @@ public class ElectrumClientTest {
   public void basicTest() {
     new JavaTestKit(system) {{
       final InetSocketAddress address = new InetSocketAddress("testnetnode.arihanc.com", 51001);
+      // TODO: how to properly instantiate SSL.OFF from java ?
       final Props props = Props.create(ElectrumClient.class, address, system.dispatcher());
       final ActorRef subject = system.actorOf(props);
 
@@ -65,7 +65,7 @@ public class ElectrumClientTest {
 
       new Within(duration("3 seconds")) {
         protected void run() {
-          subject.tell(new ElectrumClient.GetTransaction(BinaryData.apply("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202")), getRef());
+          subject.tell(new ElectrumClient.GetTransaction(ByteVector32.fromValidHex("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202")), getRef());
           ElectrumClient.GetTransactionResponse response = expectMsgClass(duration("1 second"), ElectrumClient.GetTransactionResponse.class);
           Assert.assertEquals(response.tx().txid().toString(), "c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202");
         }
@@ -73,9 +73,9 @@ public class ElectrumClientTest {
 
       new Within(duration("3 seconds")) {
         protected void run() {
-          subject.tell(new ElectrumClient.GetMerkle(BinaryData.apply("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202"), 1210223L), getRef());
+          subject.tell(new ElectrumClient.GetMerkle(ByteVector32.fromValidHex("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202"), 1210223), getRef());
           ElectrumClient.GetMerkleResponse response = expectMsgClass(duration("1 second"), ElectrumClient.GetMerkleResponse.class);
-          Assert.assertEquals(response.txid(), BinaryData.apply("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202"));
+          Assert.assertEquals(response.txid(), ByteVector32.fromValidHex("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202"));
           Assert.assertEquals(response.block_height(), 1210223L);
           Assert.assertEquals(response.pos(), 28);
         }
@@ -92,7 +92,7 @@ public class ElectrumClientTest {
       new Within(duration("3 seconds")) {
         protected void run() {
           Transaction referenceTx = (Transaction) Transaction.read("0200000003947e307df3ab452d23f02b5a65f4ada1804ee733e168e6197b0bd6cc79932b6c010000006a473044022069346ec6526454a481690a3664609f9e8032c34553015cfa2e9b25ebb420a33002206998f21a2aa771ad92a0c1083f4181a3acdb0d42ca51d01be1309da2ffb9cecf012102b4568cc6ee751f6d39f4a908b1fcffdb878f5f784a26a48c0acb0acff9d88e3bfeffffff966d9d969cd5f95bfd53003a35fcc1a50f4fb51f211596e6472583fdc5d38470000000006b4830450221009c9757515009c5709b5b678d678185202b817ef9a69ffb954144615ab11762210220732216384da4bf79340e9c46d0effba6ba92982cca998adfc3f354cec7715f800121035f7c3e077108035026f4ebd5d6ca696ef088d4f34d45d94eab4c41202ec74f9bfefffffff8d5062f5b04455c6cfa7e3f250e5a4fb44308ba2b86baf77f9ad0d782f57071010000006a47304402207f9f7dd91fe537a26d5554105977e3949a5c8c4ef53a6a3bff6da2d36eff928f02202b9427bef487a1825fd0c3c6851d17d5f19e6d73dfee22bf06db591929a2044d012102b4568cc6ee751f6d39f4a908b1fcffdb878f5f784a26a48c0acb0acff9d88e3bfeffffff02809698000000000017a914c82753548fdf4be1c3c7b14872c90b5198e67eaa876e642500000000001976a914e2365ec29471b3e271388b22eadf0e7f54d307a788ac6f771200");
-          BinaryData hash = package$.MODULE$.seq2binaryData(Crypto.sha256().apply(referenceTx.txOut().apply(0).publicKeyScript().data()).data().reverse());
+          ByteVector32 hash = Crypto.sha256().apply(referenceTx.txOut().apply(0).publicKeyScript()).reverse();
           subject.tell(new ElectrumClient.ScriptHashSubscription(hash, getRef()), getRef());
           ElectrumClient.ScriptHashSubscriptionResponse response = expectMsgClass(duration("1 second"), ElectrumClient.ScriptHashSubscriptionResponse.class);
           System.out.println("received scripthash status " + response.status());

--- a/app/src/androidTest/java/fr/acinq/eclair/crypto/BackupEncryptionTest.java
+++ b/app/src/androidTest/java/fr/acinq/eclair/crypto/BackupEncryptionTest.java
@@ -24,11 +24,9 @@ import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
 import fr.acinq.bitcoin.DeterministicWallet;
-import fr.acinq.bitcoin.package$;
-import fr.acinq.eclair.blockchain.electrum.ElectrumWallet;
 import fr.acinq.eclair.wallet.utils.EncryptedBackup;
 import fr.acinq.eclair.wallet.utils.EncryptedData;
-import fr.acinq.eclair.wallet.utils.WalletUtils;
+import scodec.bits.ByteVector;
 
 public class BackupEncryptionTest {
 
@@ -36,9 +34,9 @@ public class BackupEncryptionTest {
   public void encryptWithSeed_v1() throws GeneralSecurityException {
 
     // create a master key from a random seed
-    byte[] seed = new byte[ElectrumWallet.SEED_BYTES_LENGTH()];
+    byte[] seed = new byte[16];
     new SecureRandom().nextBytes(seed);
-    final DeterministicWallet.ExtendedPrivateKey xpriv = DeterministicWallet.generate(package$.MODULE$.array2binaryData(seed).data());
+    final DeterministicWallet.ExtendedPrivateKey xpriv = DeterministicWallet.generate(ByteVector.view(seed));
 
     // derive a hardened key from xpriv
     // hardened means that, even if the key is compromised, it is not possible to find the parent key
@@ -59,9 +57,9 @@ public class BackupEncryptionTest {
   public void encryptWithSeed_v2() throws GeneralSecurityException {
 
     // create a master key from a random seed
-    byte[] seed = new byte[ElectrumWallet.SEED_BYTES_LENGTH()];
+    byte[] seed = new byte[16];
     new SecureRandom().nextBytes(seed);
-    final DeterministicWallet.ExtendedPrivateKey xpriv = DeterministicWallet.generate(package$.MODULE$.array2binaryData(seed).data());
+    final DeterministicWallet.ExtendedPrivateKey xpriv = DeterministicWallet.generate(ByteVector.view(seed));
 
     // derive a hardened key from xpriv
     // hardened means that, even if the key is compromised, it is not possible to find the parent key

--- a/app/src/androidTest/java/fr/acinq/eclair/crypto/SeedEncryptionTest.java
+++ b/app/src/androidTest/java/fr/acinq/eclair/crypto/SeedEncryptionTest.java
@@ -28,7 +28,6 @@ import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
-import fr.acinq.eclair.blockchain.electrum.ElectrumWallet;
 import fr.acinq.eclair.wallet.utils.WalletUtils;
 
 public class SeedEncryptionTest {
@@ -50,7 +49,7 @@ public class SeedEncryptionTest {
 
   @Test
   public void writeAndReadSeed() throws IOException, GeneralSecurityException, IllegalAccessException {
-    byte[] seed = new byte[ElectrumWallet.SEED_BYTES_LENGTH()];
+    byte[] seed = new byte[16];
     new SecureRandom().nextBytes(seed);
     final File datadir = temp.newFolder("datadir_temp");
     WalletUtils.writeSeedFile(datadir, seed, password);
@@ -60,7 +59,7 @@ public class SeedEncryptionTest {
 
   @Test(expected = GeneralSecurityException.class)
   public void failReadSeedWrongPassword() throws IOException, GeneralSecurityException, IllegalAccessException {
-    byte[] seed = new byte[ElectrumWallet.SEED_BYTES_LENGTH()];
+    byte[] seed = new byte[16];
     new SecureRandom().nextBytes(seed);
     final File datadir = temp.newFolder("datadir_temp");
     WalletUtils.writeSeedFile(datadir, seed, password);

--- a/app/src/main/java/fr/acinq/eclair/wallet/App.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/App.java
@@ -82,6 +82,7 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.Duration;
 import scala.math.BigDecimal;
+import scodec.bits.ByteVector;
 import upickle.default$;
 
 import java.io.IOException;
@@ -103,15 +104,20 @@ public class App extends Application {
   public AtomicReference<String> pin = new AtomicReference<>(null);
   public AtomicReference<String> seedHash = new AtomicReference<>(null);
   // version 1 of the backup encryption key uses a m/49' path for derivation, same as BIP49
-  public AtomicReference<BinaryData> backupKey_v1 = new AtomicReference<>(null);
+  public AtomicReference<ByteVector32> backupKey_v1 = new AtomicReference<>(null);
   // version 2 of the backup encryption key uses a m/42'/0' (mainnet) or m/42'/1' (testnet) path, which is better than m/49'.
   // version 1 is kept for backward compatibility
-  public AtomicReference<BinaryData> backupKey_v2 = new AtomicReference<>(null);
+  public AtomicReference<ByteVector32> backupKey_v2 = new AtomicReference<>(null);
   public AppKit appKit;
 
   // Route params with high base fee (at most 1mBTC)
   private final Option<RouteParams> noLimitRouteParams = Option.apply(RouteParams.apply(
-    package$.MODULE$.millibtc2millisatoshi(new MilliBtc(BigDecimal.exact(1))).amount(), 1d, 10, Router.DEFAULT_ROUTE_MAX_CLTV()));
+    false,
+    package$.MODULE$.millibtc2millisatoshi(new MilliBtc(BigDecimal.exact(1))).amount(),
+    1d,
+    10,
+    Router.DEFAULT_ROUTE_MAX_CLTV(),
+    Option.empty()));
 
   private Cancellable pingNode;
 
@@ -365,8 +371,11 @@ public class App extends Application {
     try {
       // simulate multisig transaction to our self to retrieve outputs total amount
       final Crypto.PublicKey pubkey = appKit.eclairKit.nodeParams().privateKey().publicKey();
-      final BinaryData placeholderScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(pubkey, pubkey)));
-      final String placeholderAddress = Bech32.encodeWitnessAddress("mainnet".equals(BuildConfig.CHAIN) ? "bc" : "tb", (byte) 0, Crypto.hash(new SHA256Digest(), package$.MODULE$.binaryData2Seq(placeholderScript)));
+      final ByteVector placeholderScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(pubkey, pubkey)));
+      final String placeholderAddress = Bech32.encodeWitnessAddress(
+        "mainnet".equals(BuildConfig.CHAIN) ? "bc" : "tb",
+        (byte) 0,
+        Crypto.hash(new SHA256Digest(), placeholderScript));
       final Tuple2<Transaction, Satoshi> tx_fee = Await.result(appKit.electrumWallet.sendAll(placeholderAddress, feesPerKw), Duration.create(20, "seconds"));
       long available = 0;
       Iterator<TxOut> it = tx_fee._1.txOut().iterator();
@@ -491,7 +500,7 @@ public class App extends Application {
   /**
    * Asynchronously ask for the raw json data of a local channel.
    */
-  public void getLocalChannelRawData(final BinaryData channelId) {
+  public void getLocalChannelRawData(final ByteVector32 channelId) {
     Register.Forward<CMD_GETINFO$> forward = new Register.Forward<>(channelId, CMD_GETINFO$.MODULE$);
     Future<Object> future = Patterns.ask(appKit.eclairKit.register(), forward, new Timeout(Duration.create(5, "seconds")));
     future.onComplete(new OnComplete<Object>() {

--- a/app/src/main/java/fr/acinq/eclair/wallet/App.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/App.java
@@ -464,7 +464,7 @@ public class App extends Application {
    * Returns the eclair node's public key.
    */
   public String nodePublicKey() {
-    return appKit.eclairKit.nodeParams().privateKey().publicKey().toBin().toString();
+    return appKit.eclairKit.nodeParams().privateKey().publicKey().toString();
   }
 
   public static long estimateSlowFees() {

--- a/app/src/main/java/fr/acinq/eclair/wallet/App.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/App.java
@@ -289,7 +289,7 @@ public class App extends Application {
         false, // never randomize on mobile
         package$.MODULE$.millibtc2millisatoshi(new MilliBtc(BigDecimal.exact(1))).amount(), // at most 1mBTC base fee
         1d, // at most 100%
-        10,
+        4,
         Router.DEFAULT_ROUTE_MAX_CLTV(),
         Option.empty()));
 

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/ChannelDetailsActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/ChannelDetailsActivity.java
@@ -29,7 +29,6 @@ import android.text.Html;
 import android.view.View;
 import android.widget.Toast;
 import com.google.common.base.Strings;
-import fr.acinq.bitcoin.BinaryData;
 import fr.acinq.bitcoin.MilliSatoshi;
 import fr.acinq.bitcoin.Satoshi;
 import fr.acinq.eclair.CoinUnit;
@@ -46,8 +45,11 @@ import fr.acinq.eclair.wallet.fragments.CloseChannelDialog;
 import fr.acinq.eclair.wallet.models.ClosingType;
 import fr.acinq.eclair.wallet.models.LocalChannel;
 import fr.acinq.eclair.wallet.utils.WalletUtils;
+import scodec.bits.ByteVector;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
 import java.text.DateFormat;
@@ -224,7 +226,7 @@ public class ChannelDetailsActivity extends EclairActivity {
     mBinding.channelId.setValue(channel.getChannelId());
     mBinding.shortChannelId.setValue(channel.getShortChannelId());
     if (channel.getLocalFeatures() != null) {
-      final BinaryData localFeatures = BinaryData.apply(channel.getLocalFeatures());
+      final ByteVector localFeatures = ByteVector.view(Hex.decode(channel.getLocalFeatures()));
       mBinding.setHasAdvancedRoutingSync(
         Features.hasFeature(localFeatures, Features.CHANNEL_RANGE_QUERIES_BIT_OPTIONAL())
           || Features.hasFeature(localFeatures, Features.CHANNEL_RANGE_QUERIES_BIT_MANDATORY()));

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/ChannelRawDataActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/ChannelRawDataActivity.java
@@ -31,12 +31,15 @@ import android.widget.Toast;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.spongycastle.util.encoders.Hex;
 
-import fr.acinq.bitcoin.BinaryData;
+import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.eclair.wallet.R;
 import fr.acinq.eclair.wallet.adapters.LocalChannelItemHolder;
 import fr.acinq.eclair.wallet.databinding.ActivityChannelRawDataBinding;
 import fr.acinq.eclair.wallet.events.ChannelRawDataEvent;
+import scodec.bits.Bases;
+import scodec.bits.ByteVector;
 
 public class ChannelRawDataActivity extends EclairActivity {
 
@@ -73,7 +76,7 @@ public class ChannelRawDataActivity extends EclairActivity {
       if (!EventBus.getDefault().isRegistered(this)) {
         EventBus.getDefault().register(this);
       }
-      app.getLocalChannelRawData(BinaryData.apply(mChannelId));
+      app.getLocalChannelRawData(ByteVector32.apply(ByteVector.view(Hex.decode(mChannelId))));
     }
   }
 

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/CreateSeedActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/CreateSeedActivity.java
@@ -76,7 +76,7 @@ public class CreateSeedActivity extends EclairActivity implements EclairActivity
 
     try {
       mMnemonics = JavaConverters.seqAsJavaListConverter(MnemonicCode.toMnemonics(
-        fr.acinq.eclair.package$.MODULE$.randomBytes(16).data(),
+        fr.acinq.eclair.package$.MODULE$.randomBytes(16),
         MnemonicCode.englishWordlist())).asJava();
 
       final Bundle args = new Bundle();

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/CreateSeedActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/CreateSeedActivity.java
@@ -34,6 +34,7 @@ import android.view.inputmethod.InputMethodManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -51,6 +52,7 @@ import fr.acinq.eclair.wallet.fragments.WalletEncryptFragment;
 import fr.acinq.eclair.wallet.fragments.WalletPassphraseConfirmFragment;
 import fr.acinq.eclair.wallet.fragments.WalletPassphraseFragment;
 import fr.acinq.eclair.wallet.utils.Constants;
+import fr.acinq.eclair.wallet.utils.WalletUtils;
 import scala.collection.JavaConverters;
 
 public class CreateSeedActivity extends EclairActivity implements EclairActivity.EncryptSeedCallback {
@@ -296,7 +298,7 @@ public class CreateSeedActivity extends EclairActivity implements EclairActivity
           }
           final String passphrase = mPassphrase;
           final File datadir = new File(getFilesDir(), Constants.ECLAIR_DATADIR);
-          final byte[] seed = MnemonicCode.toSeed(JavaConverters.collectionAsScalaIterableConverter(mMnemonics).asScala().toSeq(), passphrase).toString().getBytes();
+          final byte[] seed = WalletUtils.mnemonicsToSeed(mMnemonics, passphrase);
           runOnUiThread(() -> encryptWallet(CreateSeedActivity.this, false, datadir, seed));
         } catch (Exception e) {
           runOnUiThread(() -> {

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/RestoreSeedActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/RestoreSeedActivity.java
@@ -43,6 +43,7 @@ import fr.acinq.eclair.wallet.fragments.WalletEncryptFragment;
 import fr.acinq.eclair.wallet.fragments.WalletImportSeedFragment;
 import fr.acinq.eclair.wallet.fragments.WalletPassphraseFragment;
 import fr.acinq.eclair.wallet.utils.Constants;
+import fr.acinq.eclair.wallet.utils.WalletUtils;
 
 public class RestoreSeedActivity extends EclairActivity implements EclairActivity.EncryptSeedCallback {
 
@@ -158,7 +159,7 @@ public class RestoreSeedActivity extends EclairActivity implements EclairActivit
     try {
       final String mnemonics = mWalletImportSeedFragment.mBinding.mnemonicsInput.getText().toString().trim();
       final String passphrase = mWalletPassphraseFragment.mBinding.passphraseInput.getText().toString();
-      MnemonicCode.toSeed(mnemonics, passphrase).toString().getBytes();
+      WalletUtils.mnemonicsToSeed(mnemonics, passphrase);
       final InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
       if (imm != null && view != null && view.getWindowToken() != null) {
         imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
@@ -189,7 +190,7 @@ public class RestoreSeedActivity extends EclairActivity implements EclairActivit
             throw new RuntimeException(getString(R.string.createwallet_invalid_seed));
           }
           final File datadir = new File(getFilesDir(), Constants.ECLAIR_DATADIR);
-          final byte[] seed = MnemonicCode.toSeed(mnemonics, passphrase).toString().getBytes();
+          final byte[] seed = WalletUtils.mnemonicsToSeed(mnemonics, passphrase);
           runOnUiThread(() -> encryptWallet(RestoreSeedActivity.this, false, datadir, seed));
         } catch (Exception e) {
           runOnUiThread(() -> {

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/SendPaymentActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/SendPaymentActivity.java
@@ -26,7 +26,8 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import fr.acinq.bitcoin.BinaryData;
+
+import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.bitcoin.MilliSatoshi;
 import fr.acinq.bitcoin.Satoshi;
 import fr.acinq.bitcoin.package$;
@@ -185,7 +186,7 @@ public class SendPaymentActivity extends EclairActivity
         mBinding.amountFiat.setText(WalletUtils.formatMsatToFiatWithUnit(amountMsat.amount(), preferredFiatCurrency));
       }
       mBinding.recipientValue.setText(paymentRequest.nodeId().toBin().toString());
-      final Either<String, BinaryData> desc = paymentRequest.description();
+      final Either<String, ByteVector32> desc = paymentRequest.description();
       mBinding.descriptionValue.setText(desc.isLeft() ? desc.left().get() : desc.right().get().toString());
       if (paymentRequest.amount().isEmpty()) {
         // only open the keyboard forcibly if no amount was set in the payment request. This makes for a cleaner initial

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/StartupActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/StartupActivity.java
@@ -37,7 +37,6 @@ import androidx.work.WorkManager;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.common.io.Files;
-import fr.acinq.bitcoin.BinaryData;
 import fr.acinq.bitcoin.DeterministicWallet;
 import fr.acinq.eclair.Kit;
 import fr.acinq.eclair.Setup;
@@ -70,6 +69,8 @@ import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.Duration;
+import scodec.bits.ByteVector;
+import scodec.bits.ByteVector$;
 
 import java.io.File;
 import java.io.IOException;
@@ -333,9 +334,9 @@ public class StartupActivity extends EclairActivity implements EclairActivity.En
       @Override
       public void run() {
         try {
-          final BinaryData seed = BinaryData.apply(new String(WalletUtils.readSeedFile(datadir, password)));
+          final ByteVector seed = ByteVector$.MODULE$.apply(WalletUtils.readSeedFile(datadir, password));
           final DeterministicWallet.ExtendedPrivateKey pk = DeterministicWallet.derivePrivateKey(
-            DeterministicWallet.generate(seed.data()), LocalKeyManager.nodeKeyBasePath(WalletUtils.getChainHash()));
+            DeterministicWallet.generate(seed), LocalKeyManager.nodeKeyBasePath(WalletUtils.getChainHash()));
           app.pin.set(password);
           app.seedHash.set(pk.privateKey().publicKey().hash160().toString());
           app.backupKey_v1.set(EncryptedBackup.generateBackupKey_v1(pk));
@@ -472,7 +473,7 @@ public class StartupActivity extends EclairActivity implements EclairActivity.En
     protected Integer doInBackground(Object... params) {
       try {
         App app = (App) params[0];
-        final BinaryData seed = (BinaryData) params[1];
+        final ByteVector seed = (ByteVector) params[1];
         final File datadir = new File(app.getFilesDir(), Constants.ECLAIR_DATADIR);
 
         publishProgress(app.getString(R.string.start_log_init));

--- a/app/src/main/java/fr/acinq/eclair/wallet/activities/StartupActivity.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/activities/StartupActivity.java
@@ -65,6 +65,8 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
+
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -334,7 +336,11 @@ public class StartupActivity extends EclairActivity implements EclairActivity.En
       @Override
       public void run() {
         try {
-          final ByteVector seed = ByteVector$.MODULE$.apply(WalletUtils.readSeedFile(datadir, password));
+          // this is a bit tricky: for compatibility reasons the actual content of the seed file
+          // is the hexadecimal representation of the seed and not the seed itself
+          final byte[] hexbytes = WalletUtils.readSeedFile(datadir, password);
+          final byte[] bytes = Hex.decode(hexbytes);
+          final ByteVector seed = ByteVector$.MODULE$.apply(bytes);
           final DeterministicWallet.ExtendedPrivateKey pk = DeterministicWallet.derivePrivateKey(
             DeterministicWallet.generate(seed), LocalKeyManager.nodeKeyBasePath(WalletUtils.getChainHash()));
           app.pin.set(password);

--- a/app/src/main/java/fr/acinq/eclair/wallet/actors/NodeSupervisor.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/actors/NodeSupervisor.java
@@ -46,10 +46,13 @@ import fr.acinq.eclair.wallet.utils.WalletUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
+
 import scala.collection.Iterator;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.util.Either;
+import scodec.bits.ByteVector;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,7 +69,7 @@ public class NodeSupervisor extends UntypedActor {
   private ActorRef channelsRefreshScheduler;
   private ActorRef balanceRefreshScheduler;
 
-  public NodeSupervisor(final DBHelper dbHelper, final String seedHash, final BinaryData backupKey,
+  public NodeSupervisor(final DBHelper dbHelper, final String seedHash, final ByteVector32 backupKey,
                         final ActorRef paymentRefreshScheduler, final ActorRef channelsRefreshScheduler, final ActorRef balanceRefreshScheduler) {
     this.dbHelper = dbHelper;
     this.channelsBackupWork = WalletUtils.generateBackupRequest(seedHash, backupKey);
@@ -106,7 +109,7 @@ public class NodeSupervisor extends UntypedActor {
   private static scala.collection.immutable.List<PaymentRequest.ExtraHop> getExtraHops(final LocalChannel channel) {
     final List<PaymentRequest.ExtraHop> hops = new ArrayList<>();
     final PaymentRequest.ExtraHop hop = new PaymentRequest.ExtraHop(
-      Crypto.PublicKey$.MODULE$.apply(BinaryData.apply(channel.getPeerNodeId()), false),
+      Crypto.PublicKey$.MODULE$.apply(ByteVector.view(Hex.decode(channel.getPeerNodeId())), false),
       ShortChannelId.apply(channel.getShortChannelId()),
       channel.feeBaseMsat,
       channel.feeProportionalMillionths,

--- a/app/src/main/java/fr/acinq/eclair/wallet/fragments/CloseChannelDialog.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/fragments/CloseChannelDialog.java
@@ -25,7 +25,6 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.TextView;
 import android.widget.Toast;
-import fr.acinq.bitcoin.BinaryData;
 import fr.acinq.bitcoin.Script;
 import fr.acinq.eclair.channel.CMD_CLOSE;
 import fr.acinq.eclair.channel.CMD_FORCECLOSE$;
@@ -35,6 +34,7 @@ import fr.acinq.eclair.wallet.utils.WalletUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
+import scodec.bits.ByteVector;
 
 public class CloseChannelDialog extends Dialog {
   private final Logger log = LoggerFactory.getLogger(CloseChannelDialog.class);
@@ -84,7 +84,7 @@ public class CloseChannelDialog extends Dialog {
         channelActorRef.tell(CMD_FORCECLOSE$.MODULE$, channelActorRef);
       } else {
         try {
-          final BinaryData closeScriptPubKey = Script.write(package$.MODULE$.addressToPublicKeyScript(closeAddress, WalletUtils.getChainHash()));
+          final ByteVector closeScriptPubKey = Script.write(package$.MODULE$.addressToPublicKeyScript(closeAddress, WalletUtils.getChainHash()));
           channelActorRef.tell(CMD_CLOSE.apply(Option.apply(closeScriptPubKey)), channelActorRef);
         } catch (Throwable t) {
           log.error("could not transform address to script pubkey", t);

--- a/app/src/main/java/fr/acinq/eclair/wallet/services/ChannelsBackupWorker.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/services/ChannelsBackupWorker.java
@@ -39,6 +39,7 @@ import com.tozny.crypto.android.AesCbcWithIntegrity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -46,13 +47,14 @@ import java.io.InputStream;
 
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
-import fr.acinq.bitcoin.BinaryData;
+import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.eclair.wallet.BuildConfig;
 import fr.acinq.eclair.wallet.activities.GoogleDriveBaseActivity;
 import fr.acinq.eclair.wallet.utils.Constants;
 import fr.acinq.eclair.wallet.utils.EncryptedBackup;
 import fr.acinq.eclair.wallet.utils.EncryptedData;
 import fr.acinq.eclair.wallet.utils.WalletUtils;
+import scodec.bits.ByteVector;
 
 public class ChannelsBackupWorker extends Worker {
   private final Logger log = LoggerFactory.getLogger(ChannelsBackupWorker.class);
@@ -90,7 +92,7 @@ public class ChannelsBackupWorker extends Worker {
 
     try {
       final MetadataBuffer buffer = Tasks.await(metadataBufferTask);
-      final AesCbcWithIntegrity.SecretKeys sk = EncryptedData.secretKeyFromBinaryKey(BinaryData.apply(key));
+      final AesCbcWithIntegrity.SecretKeys sk = EncryptedData.secretKeyFromBinaryKey(ByteVector32.apply(ByteVector.view(Hex.decode(key))));
       if (buffer.getCount() == 0) {
         Tasks.await(createBackup(context, driveResourceClient, backupFileName, sk));
       } else {

--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/EncryptedBackup.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/EncryptedBackup.java
@@ -23,7 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import fr.acinq.bitcoin.BinaryData;
+import fr.acinq.bitcoin.ByteVector32;
 import fr.acinq.bitcoin.DeterministicWallet;
 import fr.acinq.eclair.wallet.BuildConfig;
 
@@ -92,7 +92,7 @@ public class EncryptedBackup extends EncryptedData {
    * Derives a hardened key from the extended key. This is used to encrypt/decrypt the channels backup files.
    * Path is the same as BIP49.
    */
-  public static BinaryData generateBackupKey_v1(final DeterministicWallet.ExtendedPrivateKey pk) {
+  public static ByteVector32 generateBackupKey_v1(final DeterministicWallet.ExtendedPrivateKey pk) {
     final DeterministicWallet.ExtendedPrivateKey dpriv = DeterministicWallet.derivePrivateKey(pk,
       DeterministicWallet.KeyPath$.MODULE$.apply("m/49'"));
     return dpriv.secretkeybytes();
@@ -102,7 +102,7 @@ public class EncryptedBackup extends EncryptedData {
    * Derives a hardened key from the extended key. This is used to encrypt/decrypt the channels backup files.
    * Path depends on the chain used by the wallet, mainnet or testnet.
    */
-  public static BinaryData generateBackupKey_v2(final DeterministicWallet.ExtendedPrivateKey pk) {
+  public static ByteVector32 generateBackupKey_v2(final DeterministicWallet.ExtendedPrivateKey pk) {
     final DeterministicWallet.ExtendedPrivateKey dpriv = DeterministicWallet.derivePrivateKey(pk,
       DeterministicWallet.KeyPath$.MODULE$.apply("mainnet".equals(BuildConfig.CHAIN) ? "m/42'/0'" : "m/42'/1'"));
     return dpriv.secretkeybytes();

--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/EncryptedData.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/EncryptedData.java
@@ -24,8 +24,8 @@ import java.security.GeneralSecurityException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import fr.acinq.bitcoin.BinaryData;
-import fr.acinq.bitcoin.package$;
+import fr.acinq.bitcoin.ByteVector32;
+import scodec.bits.ByteVector;
 
 public abstract class EncryptedData {
 
@@ -55,8 +55,8 @@ public abstract class EncryptedData {
     return AesCbcWithIntegrity.decrypt(civ, sk);
   }
 
-  public static AesCbcWithIntegrity.SecretKeys secretKeyFromBinaryKey(final BinaryData key) {
-    final byte[] keyBytes = package$.MODULE$.binaryData2array(key);
+  public static AesCbcWithIntegrity.SecretKeys secretKeyFromBinaryKey(final ByteVector32 key) {
+    final byte[] keyBytes = key.bytes().toArray();
     final byte[] confidentialityKeyBytes = new byte[16];
     System.arraycopy(keyBytes, 0, confidentialityKeyBytes, 0, 16);
     final byte[] integrityKeyBytes = new byte[16];

--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
@@ -56,6 +56,8 @@ import fr.acinq.eclair.wallet.BuildConfig;
 import fr.acinq.eclair.wallet.R;
 import fr.acinq.eclair.wallet.services.ChannelsBackupWorker;
 import okhttp3.ResponseBody;
+import scodec.bits.ByteVector;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig;
@@ -304,7 +306,7 @@ public class WalletUtils {
     return paymentRequest.amount().isEmpty() ? new MilliSatoshi(0) : paymentRequest.amount().get();
   }
 
-  public static BinaryData getChainHash() {
+  public static ByteVector32 getChainHash() {
     return "mainnet".equals(BuildConfig.CHAIN) ? Block.LivenetGenesisBlock().hash() : Block.TestnetGenesisBlock().hash();
   }
 
@@ -325,7 +327,7 @@ public class WalletUtils {
     return "eclair_" + BuildConfig.CHAIN + "_" + seedHash + ".bkup";
   }
 
-  public static OneTimeWorkRequest generateBackupRequest(final String seedHash, final BinaryData backupKey) {
+  public static OneTimeWorkRequest generateBackupRequest(final String seedHash, final ByteVector32 backupKey) {
     return new OneTimeWorkRequest.Builder(ChannelsBackupWorker.class)
       .setInputData(new Data.Builder()
         .putString(ChannelsBackupWorker.BACKUP_NAME_INPUT, WalletUtils.getEclairBackupFileName(seedHash))
@@ -336,11 +338,8 @@ public class WalletUtils {
       .build();
   }
 
-  public static String toAscii(final BinaryData b) {
-    final byte[] bytes = new byte[b.length()];
-    for (int i = 0; i < b.length(); i++) {
-      bytes[i] = (Byte) b.data().apply(i);
-    }
+  public static String toAscii(final ByteVector b) {
+    final byte[] bytes = b.toArray();
     return new String(bytes, StandardCharsets.US_ASCII);
   }
 

--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
@@ -40,6 +40,7 @@ import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.net.HostAndPort;
 import com.papertrailapp.logback.Syslog4jAppender;
@@ -56,12 +57,14 @@ import fr.acinq.eclair.wallet.BuildConfig;
 import fr.acinq.eclair.wallet.R;
 import fr.acinq.eclair.wallet.services.ChannelsBackupWorker;
 import okhttp3.ResponseBody;
+import scala.collection.JavaConverters;
 import scodec.bits.ByteVector;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,6 +73,7 @@ import java.security.GeneralSecurityException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -169,6 +173,16 @@ public class WalletUtils {
         Toast.makeText(v.getContext(), "Could not open explorer", Toast.LENGTH_SHORT).show();
       }
     };
+  }
+
+  public static byte[] mnemonicsToSeed(List<String> mnemonics, String passphrase) {
+    final byte[] bytes = MnemonicCode.toSeed(JavaConverters.collectionAsScalaIterableConverter(mnemonics).asScala().toSeq(), passphrase).toArray();
+    final byte[] seed = Hex.encode(bytes);
+    return seed;
+  }
+
+  public static byte[] mnemonicsToSeed(String mnemonics, String passphrase) {
+    return mnemonicsToSeed(Lists.newArrayList(mnemonics.split(" ")), passphrase);
   }
 
   private static byte[] readSeedFile(final File datadir, final String seedFileName, final String password) throws IOException, IllegalAccessException, GeneralSecurityException {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,7 +413,7 @@
   <string name="networkinfos_nodeid_label">Your node id</string>
   <string name="networkinfos_blockcount_label">Block height</string>
   <string name="networkinfos_feerate_label">Current fee rate</string>
-  <string name="networkinfos_electrum_address_label">Current Electrum server</string>
+  <string name="networkinfos_electrum_address_label">Current electrum server</string>
   <string name="networkinfos_electrum_address_connecting">Establishing connection…</string>
   <string name="networkinfos_electrum_address_connecting_to_custom">Attempting connection to %1$s…</string>
   <string name="networkinfos_electrum_address_set_custom">Set custom server…</string>


### PR DESCRIPTION
This PR is a technical upgrade, migrating `BinaryData` objects to `scodec.bits.ByteVector`.

See https://github.com/ACINQ/eclair/pull/896 and https://github.com/ACINQ/bitcoin-lib/pull/31