### PR TITLE
Avoid paying 2x the fee, Avoid change creation

### DIFF
--- a/app/src/main/java/fr/acinq/eclair/wallet/App.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/App.java
@@ -390,9 +390,9 @@ public class App extends Application {
       long available = 0;
       Iterator<TxOut> it = tx_fee._1.txOut().iterator();
       while (it.hasNext()) {
+        // should be one output (the placeholder) with the total amount minus fees
         available += it.next().amount().amount();
       }
-      available -= tx_fee._2.amount();
       return new Satoshi(Math.max(0, available));
     } catch (Exception e) {
       log.error("could not retrieve max available funds after fees", e);


### PR DESCRIPTION
This fixes two issues when creating a channel:

* Fix #211
* At low fee rates, the mobile wallet would overpay the fee by a factor of 2. This is because a change can not be created due to the dust limit of 546 sat or something