### PR TITLE
OpenChannelCapacityFragment: Fix off-by-one in max capacity (take 2)

### DIFF
--- a/app/src/main/java/fr/acinq/eclair/wallet/fragments/openchannel/OpenChannelCapacityFragment.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/fragments/openchannel/OpenChannelCapacityFragment.java
@@ -177,7 +177,7 @@ public class OpenChannelCapacityFragment extends Fragment {
     try {
       final Satoshi capacity = CoinUtils.convertStringAmountToSat(amount, preferredBitcoinUnit.code());
       mBinding.capacityFiat.setText(getString(R.string.amount_to_fiat, WalletUtils.formatSatToFiatWithUnit(capacity, preferredFiatCurrency)));
-      if (capacity.$less(minFunding )|| capacity.$greater(maxFunding)) {
+      if (capacity.$less(minFunding )|| capacity.$greater$eq(maxFunding)) {
         mBinding.setAmountError(getString(R.string.openchannel_capacity_invalid, CoinUtils.formatAmountInUnit(minFunding, preferredBitcoinUnit, false),
           CoinUtils.formatAmountInUnit(maxFunding, preferredBitcoinUnit, true)));
         return null;
@@ -214,7 +214,7 @@ public class OpenChannelCapacityFragment extends Fragment {
         try {
           if (getApp() != null) {
             final long feesPerKw = fr.acinq.eclair.package$.MODULE$.feerateByte2Kw(Long.parseLong(mBinding.fundingFeesValue.getText().toString()));
-            final long capacitySat = Math.min(getApp().getAvailableFundsAfterFees(feesPerKw).toLong(), Channel.MAX_FUNDING().toLong());
+            final long capacitySat = Math.min(getApp().getAvailableFundsAfterFees(feesPerKw).toLong(), Channel.MAX_FUNDING().toLong() - 1);
             runOnUiThread(() -> {
               mBinding.capacityValue.setText(CoinUtils.rawAmountInUnit(new Satoshi(capacitySat), preferredBitcoinUnit).bigDecimal().toPlainString());
               mBinding.capacityValue.setEnabled(false);


### PR DESCRIPTION
Commit b20edad18c544c761fbd2ac1bf3f283d5a69a996 by me was incorrect. The amount must be *less than* 2^24 (https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#requirements).

Again, untested because I can't compile on my machine.