### PR TITLE
Turn off SSL when custom Electrum server address is a hidden service

### DIFF
--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
@@ -556,8 +556,14 @@ public class WalletUtils {
         if (!Strings.isNullOrEmpty(address.getHost())) {
           conf.put("eclair.electrum.host", address.getHost());
           conf.put("eclair.electrum.port", address.getPort());
-          // custom server certificate must be valid
-          conf.put("eclair.electrum.ssl", "strict");
+
+          // custom server certificate must be valid when not using Tor
+          if (address.getHost().endsWith(".onion")) {
+            conf.put("eclair.electrum.ssl", "off");
+          } else {
+            conf.put("eclair.electrum.ssl", "strict");
+          }
+
           return ConfigFactory.parseMap(conf);
         }
       } catch (Exception e) {


### PR DESCRIPTION
It would be great if I could connect the Eclair mobile wallet to my Tor only electrs server using Orbot. Sadly I can't because it requires a valid SSL certificate. Please make an exception if the custom Electrum server address is an onion domain. #untested