### PR TITLE
Support deterministic builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.10
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV ANDROID_SDK_FILENAME sdk-tools-linux-4333796.zip
+ENV ANDROID_SDK_URL https://dl.google.com/android/repository/${ANDROID_SDK_FILENAME}
+ENV ANDROID_API_LEVELS android-29
+ENV ANDROID_BUILD_TOOLS_VERSION 28.0.3
+ENV ANDROID_HOME /usr/local/android-sdk
+ENV PATH ${PATH}:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+ENV JAVA_OPTS "-Dprofile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8"
+
+# prepare env
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common locales && \
+    apt-get update -y && \
+    locale-gen en_US.UTF-8 && \
+    apt-get install -y openjdk-8-jdk wget git unzip
+
+# fetch and unpack the android sdk
+RUN mkdir /usr/local/android-sdk && \
+    cd /usr/local/android-sdk && \
+    wget -q ${ANDROID_SDK_URL} && \
+    unzip ${ANDROID_SDK_FILENAME} && \
+    rm ${ANDROID_SDK_FILENAME}
+
+# install sdk packages
+RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3" "cmake;3.6.4111459" "ndk;21.0.6113669" "patcher;v4" "platforms;android-29"
+
+# copy project over to docker image
+COPY . /home/ubuntu/eclair-mobile
+
+# make gradle wrapper executable
+RUN chmod +x /home/ubuntu/eclair-mobile/gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -7,6 +7,8 @@ ENV ANDROID_SDK_FILENAME sdk-tools-linux-4333796.zip
 ENV ANDROID_SDK_URL https://dl.google.com/android/repository/${ANDROID_SDK_FILENAME}
 ENV ANDROID_API_LEVELS android-29
 ENV ANDROID_BUILD_TOOLS_VERSION 28.0.3
+ENV ANDROID_NDK_VERSION 21.0.6113669
+ENV CMAKE_VERSION 3.6.4111459
 ENV ANDROID_HOME /usr/local/android-sdk
 ENV PATH ${PATH}:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 ENV JAVA_OPTS "-Dprofile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8"
@@ -26,7 +28,7 @@ RUN mkdir /usr/local/android-sdk && \
     rm ${ANDROID_SDK_FILENAME}
 
 # install sdk packages
-RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3" "cmake;3.6.4111459" "ndk;21.0.6113669" "patcher;v4" "platforms;android-29"
+RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" "cmake;${CMAKE_VERSION}" "ndk;${ANDROID_NDK_VERSION}" "patcher;v4" "platforms;${ANDROID_API_LEVELS}"
 
 # copy project over to docker image
 COPY . /home/ubuntu/eclair-mobile

--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ The wallet is available on [Google Play](https://play.google.com/store/apps/deta
    Follow the steps [here](https://github.com/ACINQ/eclair/blob/android/BUILD.md) to build the eclair-core library.
 
 3. Open the Eclair Mobile project with Android studio. You should now be able to install it on your phone/on an emulator.
+
+## Building eclair-mobile deterministically
+
+Eclair-mobile supports deterministic builds on Linux OSs, this allows anyone to recreate from the sources the exact same APK that was published in the release page.
+The deterministic build uses a dockerized build environment and require you to have previously built (and published locally) the artifact for the `eclair-core` 
+dependency, follow the [instructions](#Developers) to build it.
+
+### Prerequisites
+
+1. A linux machine running on x64 CPU.
+2. docker-ce installed
+3. Eclair-core published in your local maven repo, check out the [instructions](#Developers) to build it.
+
+### Steps
+
+1. Clone the project from https://github.com/ACINQ/eclair-mobile
+3. Run `docker build -t eclair-mobile .` to create the build environment
+4. Run `docker run --rm -v $HOME/.m2:/root/.m2 -v $(pwd):/home/ubuntu/eclair-mobile/app/build -w /home/ubuntu/eclair-mobile eclair-mobile ./gradlew assemble`
+5. Built artifacts are in $(pwd)/outputs/apk/release


### PR DESCRIPTION
Inspired by https://github.com/ACINQ/phoenix/pull/24 this PR adds the deterministic build environment to eclair-mobile allowing anyone to easily reproduce the released packages. To perform the build you need `docker-ce` installed and `eclair-core` published locally in your maven repo, full instructions in the README.