### PR TITLE
Electrum: disable SSL when using Tor

### DIFF
--- a/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
+++ b/app/src/main/java/fr/acinq/eclair/wallet/utils/WalletUtils.java
@@ -557,8 +557,13 @@ public class WalletUtils {
         if (!Strings.isNullOrEmpty(address.getHost())) {
           conf.put("eclair.electrum.host", address.getHost());
           conf.put("eclair.electrum.port", address.getPort());
-          // custom server certificate must be valid
-          conf.put("eclair.electrum.ssl", "strict");
+          if (address.getHost().endsWith(".onion")) {
+            // If Tor is used, we don't require TLS; Tor already adds a layer of encryption.
+            conf.put("eclair.electrum.ssl", "off");
+          } else {
+            // Otherwise we require TLS with a valid server certificate.
+            conf.put("eclair.electrum.ssl", "strict");
+          }
           return ConfigFactory.parseMap(conf);
         }
       } catch (Exception e) {


### PR DESCRIPTION
As a first step we currently disable SSL when using Tor.
We may add a checkbox in the future to allow users to opt-in to using SSL with Tor.