### PR TITLE
Change MPP default parameters

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -30,6 +30,8 @@ eclair {
   max-funding-satoshis = 50000000 // 0.5 btc
 
   router.path-finding.max-route-length = 4
+  router.path-finding.mpp.min-amount-satoshis = 1000 // minimum amount sent via partial HTLCs
+  router.path-finding.mpp.max-parts = 10 // maximum number of HTLCs sent per payment: increasing this value will negatively impact performance
   router.channel-exclude-duration = 10 seconds // 60s default is too long
   router.randomize-route-selection = false
 


### PR DESCRIPTION
Wallets send smaller amounts, and will likely need more parts than server nodes.